### PR TITLE
Various improvements

### DIFF
--- a/core-bundle/src/DependencyInjection/Attribute/AsPage.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsPage.php
@@ -20,7 +20,10 @@ namespace Contao\CoreBundle\DependencyInjection\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AsPage
 {
-    public function __construct(public ?string $type = null, public ?string $path = null, public array $requirements = [], public array $options = [], public array $defaults = [], public array $methods = [], string $locale = null, string $format = null, public bool $contentComposition = true, public ?string $urlSuffix = null)
+    /**
+     * @param string|bool|null $path
+     */
+    public function __construct(public ?string $type = null, public $path = null, public array $requirements = [], public array $options = [], public array $defaults = [], public array $methods = [], string $locale = null, string $format = null, public bool $contentComposition = true, public ?string $urlSuffix = null)
     {
         if (null !== $locale) {
             $this->defaults['_locale'] = $locale;

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -101,12 +101,6 @@ class RegisterPagesPass implements CompilerPassInterface
             $pathRegex = $compiledRoute->getRegex();
         }
 
-        if (false === $path) {
-            $attributes['options'] = array_merge([
-                'compiler_class' => UnroutablePageRouteCompiler::class,
-            ], $attributes['options'] ?? []);
-        }
-
         return new Definition(
             RouteConfig::class,
             [

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Routing;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\Model\Collection;
@@ -26,11 +27,13 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
 {
     protected ContaoFramework $framework;
     protected CandidatesInterface $candidates;
+    protected PageRegistry $pageRegistry;
 
-    public function __construct(ContaoFramework $framework, CandidatesInterface $candidates)
+    public function __construct(ContaoFramework $framework, CandidatesInterface $candidates, PageRegistry $pageRegistry)
     {
         $this->framework = $framework;
         $this->candidates = $candidates;
+        $this->pageRegistry = $pageRegistry;
     }
 
     /**
@@ -73,7 +76,13 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         }
 
         /** @var array<PageModel> */
-        return $pages->getModels();
+        $models = $pages->getModels();
+
+        $models = array_filter($models, function (PageModel $model) {
+            return $this->pageRegistry->isRoutable($model);
+        });
+
+        return $models;
     }
 
     /**

--- a/core-bundle/src/Routing/Page/UnroutablePageRouteCompiler.php
+++ b/core-bundle/src/Routing/Page/UnroutablePageRouteCompiler.php
@@ -14,16 +14,12 @@ namespace Contao\CoreBundle\Routing\Page;
 
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouteCompiler;
+use Symfony\Component\Routing\RouteCompilerInterface;
 
-class UnroutablePageRouteCompiler extends RouteCompiler
+class UnroutablePageRouteCompiler implements RouteCompilerInterface
 {
     public static function compile(Route $route)
     {
-        if ($route instanceof PageRoute) {
-            throw new RouteNotFoundException(sprintf('Cannot create route for page type "%s"', $route->getPageModel()->type));
-        }
-
-        return parent::compile($route);
+        throw new RouteNotFoundException(sprintf('Cannot create route for page type "%s"', $route->getPageModel()->type));
     }
 }

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -28,16 +28,12 @@ use Symfony\Component\Routing\RouteCollection;
 
 class Route404Provider extends AbstractPageRouteProvider
 {
-    private PageRegistry $pageRegistry;
-
     /**
      * @internal Do not inherit from this class; decorate the "contao.routing.route_404_provider" service instead
      */
     public function __construct(ContaoFramework $framework, CandidatesInterface $candidates, PageRegistry $pageRegistry)
     {
-        parent::__construct($framework, $candidates);
-
-        $this->pageRegistry = $pageRegistry;
+        parent::__construct($framework, $candidates, $pageRegistry);
     }
 
     public function getRouteCollectionForRequest(Request $request): RouteCollection
@@ -70,8 +66,8 @@ class Route404Provider extends AbstractPageRouteProvider
             throw new RouteNotFoundException('Route name does not match a page ID');
         }
 
-        $pageModel = $this->framework->getAdapter(PageModel::class);
-        $page = $pageModel->findByPk($ids[0]);
+        $pageAdapter = $this->framework->getAdapter(PageModel::class);
+        $page = $pageAdapter->findByPk($ids[0]);
 
         if (null === $page) {
             throw new RouteNotFoundException(sprintf('Page ID "%s" not found', $ids[0]));
@@ -80,7 +76,10 @@ class Route404Provider extends AbstractPageRouteProvider
         $routes = [];
 
         $this->addNotFoundRoutesForPage($page, $routes);
-        $this->addLocaleRedirectRoute($this->pageRegistry->getRoute($page), null, $routes);
+
+        if ($this->pageRegistry->isRoutable($page)) {
+            $this->addLocaleRedirectRoute($this->pageRegistry->getRoute($page), null, $routes);
+        }
 
         if (!\array_key_exists($name, $routes)) {
             throw new RouteNotFoundException('Route "'.$name.'" not found');
@@ -113,8 +112,7 @@ class Route404Provider extends AbstractPageRouteProvider
             $this->addNotFoundRoutesForPage($page, $routes);
 
             if ($this->pageRegistry->isRoutable($page)) {
-                $route = $this->pageRegistry->getRoute($page);
-                $this->addLocaleRedirectRoute($route, null, $routes);
+                $this->addLocaleRedirectRoute($this->pageRegistry->getRoute($page), null, $routes);
             }
         }
 

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -22,7 +22,6 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class PageRegistryTest extends TestCase
 {
@@ -412,12 +411,9 @@ class PageRegistryTest extends TestCase
         );
 
         $registry = new PageRegistry($this->createMock(Connection::class));
-        $registry->add('foobar', new RouteConfig(null, null, null, [], ['compiler_class' => UnroutablePageRouteCompiler::class]));
+        $registry->add('foobar', new RouteConfig(false, null, null, []));
 
         $this->assertFalse($registry->isRoutable($pageModel));
-
-        $this->expectException(RouteNotFoundException::class);
-        $registry->getRoute($pageModel);
     }
 
     private function mockConnectionWithPrefixAndSuffix(string $urlPrefix = '', string $urlSuffix = '.html'): Connection

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -886,6 +886,10 @@ class RouteProviderTest extends TestCase
 
         if (null === $pageRegistry) {
             $pageRegistry = $this->createMock(PageRegistry::class);
+            $pageRegistry
+                ->method('isRoutable')
+                ->willReturn(true)
+            ;
         }
 
         return new RouteProvider($framework, $candidates, $pageRegistry, false, $prependLocale);


### PR DESCRIPTION
- Fixed PHP8 attribute
- Allow to retrieve route config for non-routable pages (e.g. to get the controller for the PrettyErrorScreenHandler)
- Always throw an exception in our compiler class
- Restore improvements from https://github.com/contao/contao/pull/3714