### PR TITLE
Only set type to boolean if it wasn’t set explicitly

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,14 +258,13 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		$arrTypes += array_fill(0, \count($arrParams), null);
 
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{
 				// Automatically set type to boolean when no type is defined,
 				// otherwise "false" will be converted to an empty string.
-				if (null === $arrTypes[$key])
+				if (null === ($arrTypes[$key] ?? null))
 				{
 					$arrTypes[$key] = \is_bool($varParam) ? ParameterType::BOOLEAN : ParameterType::STRING;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,18 +258,16 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		if (empty($arrTypes)) {
-			$arrTypes = array_fill(0, \count($arrParams), ParameterType::STRING);
-		}
+		$arrTypes += array_fill(0, \count($arrParams), null);
 
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{
-				// Automatically set type to boolean when no type or string type is defined,
+				// Automatically set type to boolean when no type is defined,
 				// otherwise "false" will be converted to an empty string.
-				if (ParameterType::STRING === ($arrTypes[$key] ?? null) && \is_bool($varParam))
+				if (null === $arrTypes[$key])
 				{
-					$arrTypes[$key] = ParameterType::BOOLEAN;
+					$arrTypes[$key] = \is_bool($varParam) ? ParameterType::BOOLEAN : ParameterType::STRING;
 				}
 
 				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)


### PR DESCRIPTION
https://github.com/contao/contao/pull/7126

This way `$arrTypes` would always be set correctly (cannot contain holes) and we would only set it to `BOOLEAN` if no type was passed explicitly. WDYT?