### PR TITLE
Clean up and add the missing unit test

### DIFF
--- a/core-bundle/tests/EventListener/UserSessionListenerTest.php
+++ b/core-bundle/tests/EventListener/UserSessionListenerTest.php
@@ -299,6 +299,22 @@ class UserSessionListenerTest extends TestCase
         $this->addToAssertionCount(1); // does not throw an exception
     }
 
+    public function testDoesNotReplaceTheSessionInPopups(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->never())
+            ->method('getUser')
+        ;
+
+        $request = new Request();
+        $request->query->set('popup', '1');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+
+        $listener = $this->getListener(null, $security);
+        $listener($this->getRequestEvent($request));
+    }
+
     public function testFailsToReplaceTheSessionIfThereIsNoSession(): void
     {
         $user = $this->mockClassWithProperties(BackendUser::class);

--- a/core-bundle/tests/Session/SessionFactoryTest.php
+++ b/core-bundle/tests/Session/SessionFactoryTest.php
@@ -31,8 +31,7 @@ class SessionFactoryTest extends TestCase
             ->method('registerBag')
             ->with($this->callback(
                 static fn (SessionBagInterface $bag): bool => match ($bag->getStorageKey()) {
-                    SessionFactory::SESSION_BAGS['contao_frontend'] => true,
-                    SessionFactory::SESSION_BAGS['contao_backend'] => true,
+                    '_contao_fe_attributes', '_contao_be_attributes' => true,
                     default => false,
                 },
             ))
@@ -59,13 +58,7 @@ class SessionFactoryTest extends TestCase
             ->willReturn(Request::create('/contao'))
         ;
 
-        (new SessionFactory(
-            $inner,
-            $requestStack,
-            $scopeMatcher,
-        ))
-            ->createSession()
-        ;
+        (new SessionFactory($inner, $requestStack, $scopeMatcher))->createSession();
     }
 
     public function testRegistersTheFrontendAndBackendPopupBag(): void
@@ -76,8 +69,7 @@ class SessionFactoryTest extends TestCase
             ->method('registerBag')
             ->with($this->callback(
                 static fn (SessionBagInterface $bag): bool => match ($bag->getStorageKey()) {
-                    SessionFactory::SESSION_BAGS['contao_frontend'] => true,
-                    SessionFactory::SESSION_BAGS['contao_backend'].'_popup' => true,
+                    '_contao_fe_attributes', '_contao_be_attributes_popup' => true,
                     default => false,
                 },
             ))
@@ -104,12 +96,6 @@ class SessionFactoryTest extends TestCase
             ->willReturn(Request::create('/contao?popup=1'))
         ;
 
-        (new SessionFactory(
-            $inner,
-            $requestStack,
-            $scopeMatcher,
-        ))
-            ->createSession()
-        ;
+        (new SessionFactory($inner, $requestStack, $scopeMatcher))->createSession();
     }
 }


### PR DESCRIPTION
This PR adds the missing unit tests and cleans up the code by splitting the back end and front end code into two different methods instead of having an `if ('contao_backend' === $name)` condition inside the `foreach` loop.